### PR TITLE
Build optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,9 +91,9 @@ RUN --mount=type=bind,from=downloader,source=/,target=/downloads set -x && \
     "${TEMP_PACKAGES[@]}" \
     && \
     # download files from the downloader image that is now mounted at /downloader
-    cp -f /downloader/usr/bin/rbfeeder /usr/bin/rbfeeder_arm && \
-    cp -f /downloader/usr/bin/dump1090-rb /usr/bin/dump1090-rb && \
-    cp -f /downloader/usr/share/doc/rbfeeder/* /usr/share/doc/rbfeeder/ && \
+    cp -f /downloads/usr/bin/rbfeeder /usr/bin/rbfeeder_arm && \
+    cp -f /downloads/usr/bin/dump1090-rb /usr/bin/dump1090-rb && \
+    cp -f /downloads/usr/share/doc/rbfeeder/* /usr/share/doc/rbfeeder/ && \
     # install mlat-client
     tar zxf /downloader/mlatclient.tgz -C / && \
     # symlink for rbfeeder wrapper

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN \
     # KEPT_PACKAGES+=(python3-minimal) && \
     # KEPT_PACKAGES+=(python3-distutils) && \
     # TEMP_PACKAGES+=(libpython3-dev) && \
-    KEPT_PACKAGES+=(python3-setuptools) && \
+    KEPT_PACKAGES+=(python3-pkg-resources) && \
     # required to run rbfeeder
     if [ "${TARGETARCH:0:3}" != "arm" ]; then \
         dpkg --add-architecture armhf; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN set -x && \
     apt-get install -q -o Dpkg::Options::="--force-confnew" -y --no-install-recommends  --no-install-suggests \
             "${RB24_PACKAGES[@]}"
 
-FROM ghcr.io/sdr-enthusiasts/docker-baseimage:qemu
+FROM ghcr.io/sdr-enthusiasts/docker-baseimage:base
 
 # This is the final image
 
@@ -76,6 +76,7 @@ RUN \
         KEPT_PACKAGES+=(libjansson4:armhf) && \
         KEPT_PACKAGES+=(libprotobuf-c1:armhf) && \
         KEPT_PACKAGES+=(librtlsdr0:armhf); \
+        KEPT_PACKAGES+=(qemu-user-static) && \
     else \
         KEPT_PACKAGES+=(libc6) && \
         KEPT_PACKAGES+=(libcurl4) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ARG TARGETPLATFORM TARGETOS TARGETARCH
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3008,SC2086,SC2039,SC2068
-RUN --mount=type=bind,from=downloader,source=/,target=/downloads set -x && \
+RUN --mount=type=bind,from=downloader,source=/,target=/downloader set -x && \
     # define required packages
     TEMP_PACKAGES=() && \
     KEPT_PACKAGES=() && \
@@ -91,9 +91,10 @@ RUN --mount=type=bind,from=downloader,source=/,target=/downloads set -x && \
     "${TEMP_PACKAGES[@]}" \
     && \
     # download files from the downloader image that is now mounted at /downloader
-    cp -f /downloads/usr/bin/rbfeeder /usr/bin/rbfeeder_arm && \
-    cp -f /downloads/usr/bin/dump1090-rb /usr/bin/dump1090-rb && \
-    cp -f /downloads/usr/share/doc/rbfeeder/* /usr/share/doc/rbfeeder/ && \
+    mkdir -p /usr/share/doc/rbfeeder && \
+    cp -f /downloader/usr/bin/rbfeeder /usr/bin/rbfeeder_arm && \
+    cp -f /downloader/usr/bin/dump1090-rb /usr/bin/dump1090-rb && \
+    cp -f /downloader/usr/share/doc/rbfeeder/* /usr/share/doc/rbfeeder/ && \
     # install mlat-client
     tar zxf /downloader/mlatclient.tgz -C / && \
     # symlink for rbfeeder wrapper

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,10 +49,12 @@ ENV BEASTHOST=readsb \
 
 ARG TARGETPLATFORM TARGETOS TARGETARCH
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-x", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3008,SC2086,SC2039,SC2068
-RUN --mount=type=bind,from=downloader,source=/,target=/downloader set -x && \
+RUN \
+    --mount=type=bind,from=downloader,source=/,target=/downloader \
+    --mount=type=bind,source=./,target=/app/ \
     # define required packages
     TEMP_PACKAGES=() && \
     KEPT_PACKAGES=() && \
@@ -95,6 +97,7 @@ RUN --mount=type=bind,from=downloader,source=/,target=/downloader set -x && \
     cp -f /downloader/usr/bin/rbfeeder /usr/bin/rbfeeder_arm && \
     cp -f /downloader/usr/bin/dump1090-rb /usr/bin/dump1090-rb && \
     cp -f /downloader/usr/share/doc/rbfeeder/* /usr/share/doc/rbfeeder/ && \
+    cp -f /app/rootfs/usr/bin/rbfeeder_wrapper.sh /usr/bin/rbfeeder_wrapper.sh && \
     # install mlat-client
     tar zxf /downloader/mlatclient.tgz -C / && \
     # symlink for rbfeeder wrapper

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,8 +75,8 @@ RUN \
         KEPT_PACKAGES+=(libglib2.0-0:armhf) && \
         KEPT_PACKAGES+=(libjansson4:armhf) && \
         KEPT_PACKAGES+=(libprotobuf-c1:armhf) && \
-        KEPT_PACKAGES+=(librtlsdr0:armhf); \
-        KEPT_PACKAGES+=(qemu-user-static) && \
+        KEPT_PACKAGES+=(librtlsdr0:armhf) && \
+        KEPT_PACKAGES+=(qemu-user-static); \
     else \
         KEPT_PACKAGES+=(libc6) && \
         KEPT_PACKAGES+=(libcurl4) && \


### PR DESCRIPTION
- use image mounts in the RUN command to avoid having to use COPY -- this reduces the number of layers that is generated for the image
- ensure that `qemu-static-arm` is included only on non-ARM platforms
- use smaller `python3-pkg-resources` instead of `python3-setuptools`