### PR TITLE
use less resources and space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,8 @@ RUN \
     /usr/bin/rbfeeder --version && \
     RBFEEDER_VERSION=$(/usr/bin/rbfeeder --no-start --version | cut -d " " -f 2,4 | tr -d ")" | tr " " "-") && \
     echo "$RBFEEDER_VERSION" > /CONTAINER_VERSION && \
+    # delete unnecessary qemu binaries to save lots of space
+    rm -f $(ls /usr/bin/qemu-*-static | grep -v qemu-arm-static) && \
     # clean up
     apt-get remove -y "${TEMP_PACKAGES[@]}" && \
     apt-get autoremove -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,6 @@ RUN \
         KEPT_PACKAGES+=(librtlsdr0); \
     fi && \
     KEPT_PACKAGES+=(netbase) && \
-    KEPT_PACKAGES+=(tcpdump) && \
     # install packages
     apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/rootfs/etc/s6-overlay/scripts/watchdog
+++ b/rootfs/etc/s6-overlay/scripts/watchdog
@@ -23,17 +23,17 @@ else
     if chk_enabled "$VERBOSE_LOGGING"; then "${s6wrap[@]}" echo "[INFO] $LASTLOG_NUM_PACKETS_SENT packets sent in past 30 seconds. HEALTHY"; fi 
 fi
 
-# monitor if there is incoming traffic from $BEASTHOST:
-PACKETS_RECEIVED="$(grep captured <<< "$(timeout --preserve-status 3 tcpdump -p src "${BEASTHOST}" and port "${BEASTPORT}" 2>/dev/stdout 1>/dev/null)" | awk '{print $1}')"
-if (( PACKETS_RECEIVED == 0 )); then
-    "${s6wrap[@]}" echo "[WARNING] No packets received from $BEASTHOST:$BEASTPORT. Restarting rbfeeder binary"
+CUR_BEASTIP="$(sed -n 's/external_host=\(.*\)/\1/p' /etc/rbfeeder.ini)"
+
+# Check TCP connection to CUR_BEAST_IP
+if ! netstat -tpn | grep -qs -e "$CUR_BEASTIP:$BEASTPORT *ESTABLISHED"; then
+    "${s6wrap[@]}" echo "[WARNING] No TCP connection to $BEASTHOST:$BEASTPORT. Restarting rbfeeder binary"
     HEALTHY=false
 else
-    if chk_enabled "$VERBOSE_LOGGING"; then "${s6wrap[@]}" echo "[INFO] $PACKETS_RECEIVED packets received from $BEASTHOST:$BEASTPORT over the last 3 seconds. HEALTHY"; fi 
+    if chk_enabled "$VERBOSE_LOGGING"; then "${s6wrap[@]}" echo "[INFO] TCP connection to $BEASTHOST:$BEASTPORT established. HEALTHY"; fi
 fi
 
 # check that BEASTHOST's IP hasn't changed
-CUR_BEASTIP="$(sed -n 's/external_host=\(.*\)/\1/p' /etc/rbfeeder.ini)"
 NEW_BEASTIP="$(s6-dnsip4 "$BEASTHOST" 2>/dev/null | head -1)" || true
 if [[ -z "$NEW_BEASTIP" ]]; then 
     # if s6-dnsip4 didn't return an IP address, it was probably because it BEASTHOST was already an IP address


### PR DESCRIPTION
- use netstat instead of tcpdump
- delete uneeded qemu binaries

Should also fix https://github.com/sdr-enthusiasts/docker-radarbox/issues/217
As netstat checks for an established connection rather than checking packets which might not be there if there is no traffic.