### PR TITLE
Fix path and bash idiom in version_0.4.3_workarounds.md

### DIFF
--- a/version_0.4.3_workarounds.md
+++ b/version_0.4.3_workarounds.md
@@ -22,7 +22,7 @@ echo 24000 > /opt/adsb/rb/thermal_zone0/temp
 
 You can now map this file into your container.
 
-If using `docker run`, simply add `-v /opt/adsb/rb/radarbox_segfault_fix:/sys/class/thermal:ro` to your command.
+If using `docker run`, simply add `-v /opt/adsb/rb:/sys/class/thermal:ro` to your command.
 
 If using `docker-compose`, add the following to the `volumes:` section of your radarbox container definition:
 
@@ -47,7 +47,7 @@ cp /proc/cpuinfo /opt/adsb/rb/fake_cpuinfo
 chmod u+w /opt/adsb/rb/fake_cpuinfo
 
 # ... make sure we have hexdump installed
-[[ ! which hexdump >/dev/null 2>&1 ]] && sudo apt install -y bsdmainutils
+command -v hexdump >/dev/null 2>&1 || sudo apt install -y bsdmainutils
 
 # ... and add a fake serial number to the end
 echo -e "serial\t\t: $(hexdump -n 8 -e '4/4 "%08X" 1 "\n"' /dev/urandom | tr '[:upper:]' '[:lower:]')" >> /opt/adsb/rb/fake_cpuinfo


### PR DESCRIPTION
Two small bugs in the non-Raspberry Pi workaround doc that bite when followed verbatim.

### 1. Wrong volume path in the temperature sensor `docker run` example

The setup steps create `/opt/adsb/rb/thermal_zone0/temp`, but the `docker run` example tells the reader to mount a different directory:

```diff
-If using `docker run`, simply add `-v /opt/adsb/rb/radarbox_segfault_fix:/sys/class/thermal:ro` to your command.
+If using `docker run`, simply add `-v /opt/adsb/rb:/sys/class/thermal:ro` to your command.
```

`radarbox_segfault_fix` is never created anywhere in the doc. Mounting it leaves the container with an empty/missing `/sys/class/thermal/thermal_zone0/temp` and `rbfeeder` segfaults — the same failure mode the workaround is meant to fix. The `docker-compose` example three lines below already mounts the parent `/opt/adsb/rb`, so this just aligns `docker run` with it.

A previous report ([#186](https://github.com/sdr-enthusiasts/docker-airnavradar/issues/186)) flagged a related path mismatch and was closed; this is the same class of error in the same paragraph.

### 2. `[[ ! which … ]]` doesn't actually run `which`

```diff
 # ... make sure we have hexdump installed
-[[ ! which hexdump >/dev/null 2>&1 ]] && sudo apt install -y bsdmainutils
+command -v hexdump >/dev/null 2>&1 || sudo apt install -y bsdmainutils
```

`[[ ]]` is a conditional expression, not a command runner. `[[ ! which hexdump ]]` parses `which` and `hexdump` as two strings — the test never reflects whether hexdump is installed, and the redirections apply to the `[[` itself rather than to a `which` invocation. `command -v` is also more portable than `which`, which doesn't exist on minimal Ubuntu/Debian images by default (the very platforms this workaround targets).

### Verification

Tested the corrected `docker run` mount on an x86_64 Ubuntu 24.04 host running rbfeeder via `qemu-arm-static`: container boots without the segfault and rbfeeder feeds AirNav Radar successfully.