### PR TITLE
Make docker-compose mount read-only and fix hexdump width in workaround doc

### DIFF
--- a/version_0.4.3_workarounds.md
+++ b/version_0.4.3_workarounds.md
@@ -22,7 +22,7 @@ echo 24000 > /opt/adsb/rb/thermal_zone0/temp
 
 You can now map this file into your container.
 
-If using `docker run`, simply add `-v /opt/adsb/rb/radarbox_segfault_fix:/sys/class/thermal:ro` to your command.
+If using `docker run`, simply add `-v /opt/adsb/rb:/sys/class/thermal:ro` to your command.
 
 If using `docker-compose`, add the following to the `volumes:` section of your radarbox container definition:
 
@@ -47,7 +47,7 @@ cp /proc/cpuinfo /opt/adsb/rb/fake_cpuinfo
 chmod u+w /opt/adsb/rb/fake_cpuinfo
 
 # ... make sure we have hexdump installed
-[[ ! which hexdump >/dev/null 2>&1 ]] && sudo apt install -y bsdmainutils
+command -v hexdump >/dev/null 2>&1 || sudo apt install -y bsdmainutils
 
 # ... and add a fake serial number to the end
 echo -e "serial\t\t: $(hexdump -n 8 -e '4/4 "%08X" 1 "\n"' /dev/urandom | tr '[:upper:]' '[:lower:]')" >> /opt/adsb/rb/fake_cpuinfo

--- a/version_0.4.3_workarounds.md
+++ b/version_0.4.3_workarounds.md
@@ -28,7 +28,7 @@ If using `docker-compose`, add the following to the `volumes:` section of your r
 
 ```yaml
 volumes:
-  - /opt/adsb/rb/:/sys/class/thermal
+  - /opt/adsb/rb/:/sys/class/thermal:ro
 ```
 
 ### Workaround for CPU Serial (should no longer be necessary)
@@ -50,7 +50,7 @@ chmod u+w /opt/adsb/rb/fake_cpuinfo
 command -v hexdump >/dev/null 2>&1 || sudo apt install -y bsdmainutils
 
 # ... and add a fake serial number to the end
-echo -e "serial\t\t: $(hexdump -n 8 -e '4/4 "%08X" 1 "\n"' /dev/urandom | tr '[:upper:]' '[:lower:]')" >> /opt/adsb/rb/fake_cpuinfo
+echo -e "serial\t\t: $(hexdump -n 8 -e '2/4 "%08X" 1 "\n"' /dev/urandom | tr '[:upper:]' '[:lower:]')" >> /opt/adsb/rb/fake_cpuinfo
 ```
 
 The `hexdump...` in the command above will generate a random hexadecimal number in the format of a Raspberry Pi serial number.


### PR DESCRIPTION
> Stacked on top of #294 — please merge that first; this PR's diff against `main` will then be just these two lines. (If preferred, I'm happy to rebase or squash either way.)

Two consistency fixes in `version_0.4.3_workarounds.md`.

### 1. `:ro` on the docker-compose mount

```diff
 volumes:
-  - /opt/adsb/rb/:/sys/class/thermal
+  - /opt/adsb/rb/:/sys/class/thermal:ro
```

The `docker run` example three lines above mounts the fake sysfs read-only, but the `docker-compose` example mounts it read-write. `rbfeeder` only reads `temp`, so both forms should be `:ro` for consistency, and a writable mount means a misbehaving container could silently mutate `/opt/adsb/rb/thermal_zone0/temp` on the host.

### 2. hexdump width matches an RPi serial

```diff
-echo -e "serial\t\t: $(hexdump -n 8 -e '4/4 "%08X" 1 "\n"' /dev/urandom | tr '[:upper:]' '[:lower:]')" >> /opt/adsb/rb/fake_cpuinfo
+echo -e "serial\t\t: $(hexdump -n 8 -e '2/4 "%08X" 1 "\n"' /dev/urandom | tr '[:upper:]' '[:lower:]')" >> /opt/adsb/rb/fake_cpuinfo
```

`hexdump -n 8` reads 8 bytes, but `4/4 "%08X"` is "repeat 4 times, consume 4 bytes per iteration" — that's 16 bytes worth of format with only 8 bytes of input, so hexdump pads/repeats and emits 32 hex chars. Raspberry Pi serials in `/proc/cpuinfo` are conventionally 16 hex chars (e.g. `0000000012345678`); `2/4 "%08X"` consumes exactly the 8 bytes read and produces a 16-char serial that matches the format `rbfeeder` greps for.

Happy to drop either fix if you'd rather keep them separate.