### PR TITLE
ci: fix DL3025 and enable the hadolint pre-commit hook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,4 +139,4 @@ COPY rootfs/ /
 EXPOSE 32088/tcp 30105/tcp
 
 # Add healthcheck
-HEALTHCHECK --start-period=3600s --interval=600s  CMD /healthcheck.sh
+HEALTHCHECK --start-period=3600s --interval=600s  CMD ["/healthcheck.sh"]

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
 
           # ── Feature toggles ─────────────────────────────
           check_rust = false;
-          check_docker = false;
+          check_docker = true;
           check_python = false;
 
           # Rust-specific knobs (safe to leave here)


### PR DESCRIPTION
## Problem

Two separate issues, neither currently visible.

**DL3025.** hadolint [#1209](https://github.com/hadolint/hadolint/pull/1209) extended `DL3025` to fire on `HEALTHCHECK ... CMD` as well as `CMD`/`ENTRYPOINT`, shipping in v2.15.0 (published 2026-07-30T13:39:01Z). `DL3025` itself is not new; only the `HEALTHCHECK` coverage is.

```console
$ hadolint --config <shared ruleset> Dockerfile     # 2.14.0, the flake.lock pin
Dockerfile:9 SC2035 info: Use ./*glob* or -- *glob* so names with dashes won't become options.
rc=0

$ hadolint --config <shared ruleset> Dockerfile     # 2.15.1
Dockerfile:9   SC2035 info: ...
Dockerfile:142 DL3025 warning: Use arguments JSON notation for CMD and ENTRYPOINT arguments
rc=1
```

**No Dockerfile linting at all.** `check_docker` defaults to `false` in the shared ruleset (`FredSystems/pre-commit-checks`, `check_docker ? false`) and this repo never set it, so the generated pre-commit config carried no `hadolint` hook. There is no hadolint job in the deploy workflow either, so nothing in CI has ever linted this Dockerfile — which is why the finding above would otherwise have surfaced only when a `flake.lock` bump landed 2.15.x.

## Changes

**`fix: use JSON exec form for HEALTHCHECK CMD`**

```diff
-HEALTHCHECK --start-period=3600s --interval=600s  CMD /healthcheck.sh
+HEALTHCHECK --start-period=3600s --interval=600s  CMD ["/healthcheck.sh"]
```

**`ci: enable the shared hadolint pre-commit hook`** — `check_docker = false` → `true`, ordered after the fix so `Lint` is not red at any intermediate commit.

`SC2035` at `Dockerfile:9` remains and is expected to: it is **`info`**, below the shared ruleset's `failure-threshold: warning`, so it reports without failing. Pre-existing and unrelated to the 2.15.x rule additions.

## Verification

The exec form drops the intervening `/bin/sh -c`, so the kernel must resolve the script's shebang itself. This is the **only healthcheck in the fleet using `#!/usr/bin/env bash`** rather than s6-overlay's `#!/command/with-contenv bash`, so the interpreter to verify is `env`:

```console
$ docker run --rm --entrypoint /bin/sh ghcr.io/sdr-enthusiasts/docker-airnavradar:latest \
    -c 'ls -l /usr/bin/env; ls -l /healthcheck.sh; head -1 /healthcheck.sh'
-rwxr-xr-x 1 root root 56144 /usr/bin/env
-rwxr-xr-x 1 root root 1236 /healthcheck.sh
#!/usr/bin/env bash
```

Both forms side by side under Docker's real healthcheck machinery — the **published image** (shell form) against a **local build of this branch** (exec form), with only the probe timing overridden:

```text
=== published / shell ===              === rebuilt / exec ===
unhealthy                              unhealthy
["CMD-SHELL","/healthcheck.sh"]        ["CMD","/healthcheck.sh"]
exit=1                                 exit=1
```

Byte-identical output on both sides:

```text
grep: /var/log/rbfeeder.log: No such file or directory
No packets sent in past 300 seconds. UNHEALTHY
```

`unhealthy` is expected without a configured AirNav sharing key and upstream feed; identical failure on both sides proves form-equivalence just as well as identical success would, and confirms exit codes still propagate in exec form.

Image config compared against the published image — only `Test[0]` differs:

```console
built    : {"Test":["CMD","/healthcheck.sh"],"Interval":600000000000,"StartPeriod":3600000000000}
published: {"Test":["CMD-SHELL","/healthcheck.sh"],"Interval":600000000000,"StartPeriod":3600000000000}
```

`Config.Entrypoint` is `["/init"]` on both, so s6 remains PID 1 and `docker stop` still reaches it for graceful shutdown.

Also checked:

- `nix develop -c pre-commit run --all-files`: green. `hadolint` now appears in the run — it did not before this branch, which is the direct evidence the `check_docker` flip took effect
- `docker build --platform linux/amd64`: succeeds
- The `ENV` block precedes `SHELL` in this Dockerfile, so it is not exposed to the hadolint 2.15.x shell-tracking regression (`ARG`/`ENV` after `SHELL` resets the dialect to POSIX sh and spuriously reports `SC3xxx`)
- No hooks bypassed; no `--no-verify`
